### PR TITLE
Preserve CIoU semantics in TAL fix

### DIFF
--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -198,21 +198,10 @@ class TaskAlignedAssigner(nn.Module):
         if b_idx.numel():
             bbox_scores[b_idx, box_idx, anch_idx] = temp_scores[b_idx, box_idx, anch_idx]
 
-            pd_boxes_exp = pd_bboxes.unsqueeze(1).expand(-1, self.n_max_boxes, -1, -1)
-            gt_boxes_exp = gt_bboxes.unsqueeze(2).expand(-1, -1, na, -1)
-
-            pd_pair = pd_boxes_exp[b_idx, box_idx, anch_idx]
-            gt_pair = gt_boxes_exp[b_idx, box_idx, anch_idx]
-
-            x1 = torch.maximum(gt_pair[:, 0], pd_pair[:, 0])
-            y1 = torch.maximum(gt_pair[:, 1], pd_pair[:, 1])
-            x2 = torch.minimum(gt_pair[:, 2], pd_pair[:, 2])
-            y2 = torch.minimum(gt_pair[:, 3], pd_pair[:, 3])
-
-            inter = (x2 - x1).clamp(min=0) * (y2 - y1).clamp(min=0)
-            area_gt = (gt_pair[:, 2] - gt_pair[:, 0]).clamp(min=0) * (gt_pair[:, 3] - gt_pair[:, 1]).clamp(min=0)
-            area_pd = (pd_pair[:, 2] - pd_pair[:, 0]).clamp(min=0) * (pd_pair[:, 3] - pd_pair[:, 1]).clamp(min=0)
-            overlaps[b_idx, box_idx, anch_idx] = inter / (area_gt + area_pd - inter + self.eps)
+            # Preserve the existing CIoU-based overlap metric while avoiding boolean masked writes.
+            pd_pair = pd_bboxes[b_idx, anch_idx]
+            gt_pair = gt_bboxes[b_idx, box_idx]
+            overlaps[b_idx, box_idx, anch_idx] = self.iou_calculation(gt_pair, pd_pair)
 
         align_metric = bbox_scores.pow(self.alpha) * overlaps.pow(self.beta)
         return align_metric, overlaps


### PR DESCRIPTION
## Summary

This is a follow-up to the TAL indexing fix. It keeps the explicit index-based gather/scatter path that avoids the boolean-mask shape mismatch, but restores the assigner's original CIoU-based overlap metric.

## Problem

The previous TAL fix replaced boolean-masked writes in `TaskAlignedAssigner.get_box_metrics()` with explicit indexing, which fixed the shape-mismatch crash. However, the overlap calculation was rewritten to plain IoU instead of preserving `self.iou_calculation(...)`, which currently uses `bbox_iou(..., CIoU=True).clamp_(0)`.

That changes assignment semantics during training because `align_metric` depends directly on the overlap term.

## Fix

This PR keeps the explicit indexing approach and changes only the overlap path:

- gather matched predicted boxes with `pd_bboxes[b_idx, anch_idx]`
- gather matched ground-truth boxes with `gt_bboxes[b_idx, box_idx]`
- compute overlaps via `self.iou_calculation(gt_pair, pd_pair)`
- scatter the result back into `overlaps[b_idx, box_idx, anch_idx]`

## Why

This preserves the original assigner behavior while still avoiding the fragile boolean-masked assignment path that caused the runtime shape mismatch.

## Scope

This is intentionally narrow and only adjusts the overlap computation inside `TaskAlignedAssigner.get_box_metrics()`.

## Validation

- reviewed against the current `tal.py` assigner semantics
- preserves the existing CIoU-based overlap metric
- keeps the explicit indexing structure from the original bug fix