### PR TITLE
Fix TaskAlignedAssigner MPS fallback

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -996,81 +996,28 @@ def test_process_mask_empty():
     assert ops.scale_masks(torch.zeros(1, 0, 160, 160), (640, 640)).shape == (1, 0, 640, 640)
 
 
-def test_task_aligned_assigner_get_box_metrics_shape_mismatch_regression():
-    """Regression test for sparse get_box_metrics masks across dense-label batches."""
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is not available")
+def test_task_aligned_assigner_mps_fallback():
+    """TaskAlignedAssigner should avoid nondeterministic MPS indexing failures by running on CPU."""
     from ultralytics.utils.tal import TaskAlignedAssigner
 
-    bs, n_max_boxes, num_anchors, num_classes = 2, 5, 37, 6
+    torch.manual_seed(0)
+    device = torch.device("mps")
+    bs, n_max_boxes, num_anchors, num_classes = 8, 300, 8400, 80
+    pd_scores = torch.rand(bs, num_anchors, num_classes, device=device)
+    pd_xy = torch.rand(bs, num_anchors, 2, device=device) * 620
+    pd_bboxes = torch.cat((pd_xy, pd_xy + torch.rand(bs, num_anchors, 2, device=device) * 30 + 5), dim=-1)
+    anc_points = torch.rand(num_anchors, 2, device=device) * 640
+    gt_labels = torch.randint(num_classes, (bs, n_max_boxes, 1), device=device)
+    gt_xy = torch.rand(bs, n_max_boxes, 2, device=device) * 620
+    gt_bboxes = torch.cat((gt_xy, gt_xy + torch.rand(bs, n_max_boxes, 2, device=device) * 30 + 5), dim=-1)
+    mask_gt = torch.ones(bs, n_max_boxes, 1, dtype=torch.bool, device=device)
     assigner = TaskAlignedAssigner(num_classes=num_classes)
-    assigner.bs = bs
-    assigner.n_max_boxes = n_max_boxes
 
-    pd_scores = torch.linspace(0.01, 0.99, bs * num_anchors * num_classes).view(bs, num_anchors, num_classes)
-
-    anchor_idx = torch.arange(num_anchors, dtype=torch.float32)
-    base_x = anchor_idx.remainder(9) * 3.0
-    base_y = torch.div(anchor_idx, 9, rounding_mode="floor") * 4.0
-    base_boxes = torch.stack((base_x, base_y, base_x + 5.0, base_y + 6.0), dim=-1)
-    pd_bboxes = torch.stack((base_boxes, base_boxes + torch.tensor([0.5, 0.25, 0.5, 0.25])))
-
-    gt_labels = torch.tensor([[[0], [2], [5], [1], [4]], [[3], [1], [0], [5], [2]]])
-    gt_bboxes = torch.tensor(
-        [
-            [
-                [0.0, 0.0, 5.5, 6.5],
-                [9.0, 0.0, 15.0, 7.0],
-                [6.0, 8.0, 12.0, 15.0],
-                [18.0, 12.0, 26.0, 20.0],
-                [0.0, 16.0, 6.0, 24.0],
-            ],
-            [
-                [1.0, 1.0, 7.0, 8.0],
-                [15.0, 4.0, 22.0, 12.0],
-                [6.0, 12.0, 13.0, 20.0],
-                [21.0, 0.0, 29.0, 9.0],
-                [3.0, 20.0, 11.0, 29.0],
-            ],
-        ]
-    )
-
-    # The pre-fix implementation indexed zero-stride tensors produced by expand() with this 3D boolean mask, e.g.
-    # `gt_bboxes.unsqueeze(2).expand(-1, -1, na, -1)[mask_gt]`. On dense, non-rectangular batches this can break on
-    # accelerators with an out-of-bounds/shape-mismatch error; explicit batch/GT/anchor indices avoid that path.
-    mask_gt = torch.zeros(bs, n_max_boxes, num_anchors, dtype=torch.bool)
-    masked_pairs = (
-        (0, 0, 0),
-        (0, 0, 10),
-        (0, 1, 3),
-        (0, 2, 20),
-        (0, 2, 29),
-        (0, 4, 36),
-        (1, 0, 1),
-        (1, 1, 5),
-        (1, 1, 14),
-        (1, 3, 7),
-        (1, 4, 31),
-        (1, 4, 35),
-    )
-    for pair in masked_pairs:
-        mask_gt[pair] = True
-
-    align_metric, overlaps = assigner.get_box_metrics(pd_scores, pd_bboxes, gt_labels, gt_bboxes, mask_gt)
-
-    assert align_metric.shape == (bs, n_max_boxes, num_anchors)
-    assert overlaps.shape == (bs, n_max_boxes, num_anchors)
-    assert torch.isfinite(align_metric).all()
-    assert torch.isfinite(overlaps).all()
-
-    b_idx, gt_idx, anchor_idx = torch.where(mask_gt)
-    expected_overlaps = assigner.iou_calculation(gt_bboxes[b_idx, gt_idx], pd_bboxes[b_idx, anchor_idx])
-    expected_scores = pd_scores[b_idx, anchor_idx, gt_labels[b_idx, gt_idx, 0]]
-    expected_align_metric = expected_scores.pow(assigner.alpha) * expected_overlaps.pow(assigner.beta)
-
-    assert expected_overlaps.gt(0).any()
-    assert torch.allclose(overlaps[b_idx, gt_idx, anchor_idx], expected_overlaps)
-    assert torch.allclose(align_metric[b_idx, gt_idx, anchor_idx], expected_align_metric)
-    assert not overlaps[~mask_gt].any()
-    assert not align_metric[~mask_gt].any()
+    for _ in range(20):
+        outputs = assigner(pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt)
+        torch.mps.synchronize()
+        assert all(output.device.type == "mps" for output in outputs)
 
 
 def test_utils_files(tmp_path):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1014,6 +1014,7 @@ def test_task_aligned_assigner_mps_fallback():
     mask_gt = torch.ones(bs, n_max_boxes, 1, dtype=torch.bool, device=device)
     assigner = TaskAlignedAssigner(num_classes=num_classes)
 
+    # Repeat to exercise the nondeterministic PyTorch 2.9.1 MPS indexing failure seen on the pre-fix path.
     for _ in range(20):
         outputs = assigner(pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt)
         torch.mps.synchronize()

--- a/ultralytics/utils/tal.py
+++ b/ultralytics/utils/tal.py
@@ -94,6 +94,12 @@ class TaskAlignedAssigner(nn.Module):
                 torch.zeros_like(pd_scores[..., 0]),
             )
 
+        if device.type == "mps":
+            result = self._forward(
+                *(t.cpu() for t in (pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt))
+            )
+            return tuple(t.to(device) for t in result)
+
         try:
             return self._forward(pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt)
         except RuntimeError as e:
@@ -188,20 +194,16 @@ class TaskAlignedAssigner(nn.Module):
         overlaps = torch.zeros([self.bs, self.n_max_boxes, na], dtype=pd_bboxes.dtype, device=pd_bboxes.device)
         bbox_scores = torch.zeros([self.bs, self.n_max_boxes, na], dtype=pd_scores.dtype, device=pd_scores.device)
 
-        ind = torch.zeros([2, self.bs, self.n_max_boxes], dtype=torch.long, device=mask_gt.device)
-        ind[0] = torch.arange(self.bs, device=mask_gt.device).view(-1, 1).expand(-1, self.n_max_boxes)
-        ind[1] = gt_labels.squeeze(-1)
+        ind = torch.zeros([2, self.bs, self.n_max_boxes], dtype=torch.long)  # 2, b, max_num_obj
+        ind[0] = torch.arange(end=self.bs).view(-1, 1).expand(-1, self.n_max_boxes)  # b, max_num_obj
+        ind[1] = gt_labels.squeeze(-1)  # b, max_num_obj
+        # Get the scores of each grid for each gt cls
+        bbox_scores[mask_gt] = pd_scores[ind[0], :, ind[1]][mask_gt]  # b, max_num_obj, h*w
 
-        # Avoid boolean masked writes on expanded tensors, which can misalign under newer torch/ultralytics combos.
-        temp_scores = pd_scores[ind[0], :, ind[1]]  # (bs, n_max_boxes, num_anchors)
-        b_idx, box_idx, anch_idx = torch.where(mask_gt)
-        if b_idx.numel():
-            bbox_scores[b_idx, box_idx, anch_idx] = temp_scores[b_idx, box_idx, anch_idx]
-
-            # Preserve the existing CIoU-based overlap metric while avoiding boolean masked writes.
-            pd_pair = pd_bboxes[b_idx, anch_idx]
-            gt_pair = gt_bboxes[b_idx, box_idx]
-            overlaps[b_idx, box_idx, anch_idx] = self.iou_calculation(gt_pair, pd_pair)
+        # (b, max_num_obj, 1, 4), (b, 1, h*w, 4)
+        pd_boxes = pd_bboxes.unsqueeze(1).expand(-1, self.n_max_boxes, -1, -1)[mask_gt]
+        gt_boxes = gt_bboxes.unsqueeze(2).expand(-1, -1, na, -1)[mask_gt]
+        overlaps[mask_gt] = self.iou_calculation(gt_boxes, pd_boxes)
 
         align_metric = bbox_scores.pow(self.alpha) * overlaps.pow(self.beta)
         return align_metric, overlaps


### PR DESCRIPTION
## Summary

- run TaskAlignedAssigner on CPU for MPS inputs and move outputs back to MPS
- restore the upstream get_box_metrics implementation
- replace the CPU-only regression with a real MPS-gated stress test

This addresses the remaining review feedback on ultralytics/ultralytics#24200.

## Testing

- real MPS regression passed on Apple M4 Pro with PyTorch 2.9.1 and 2.11.0
- the pre-fix PyTorch 2.9.1 path reproduced the nondeterministic shape mismatch
- the test skips when MPS is unavailable
- Python compilation and git diff checks passed